### PR TITLE
fix: prevent objectives from completing early in workflow level 3.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "git-mastery",
-    "version": "1.9.3",
+    "version": "1.9.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "git-mastery",
-            "version": "1.9.3",
+            "version": "1.9.8",
             "dependencies": {
                 "@radix-ui/react-accordion": "^1.2.3",
                 "@radix-ui/react-dialog": "^1.1.1",

--- a/src/levels/stages/workflow.ts
+++ b/src/levels/stages/workflow.ts
@@ -217,6 +217,7 @@ const workflowLevel3 = createLevel({
     requirements: [
         {
             id: "create-release-branch",
+            objectiveId:1,
             command: "git switch",
             alternativeCommands: ["git checkout"],
             requiresArgs: ["-c"],
@@ -225,12 +226,14 @@ const workflowLevel3 = createLevel({
         },
         {
             id: "stage-release-changes",
+            objectiveId:2,
             command: "git add",
             description: "workflow.level3.requirement2.description",
             successMessage: "workflow.level3.requirement2.success"
         },
         {
             id: "commit-release",
+            objectiveId:2,
             command: "git commit",
             requiresArgs: ["any"],
             description: "workflow.level3.requirement3.description",
@@ -238,6 +241,7 @@ const workflowLevel3 = createLevel({
         },
         {
             id: "switch-to-main-for-release",
+            objectiveId:3,
             command: "git switch",
             alternativeCommands: ["git checkout"],
             requiresArgs: ["main"],
@@ -246,6 +250,7 @@ const workflowLevel3 = createLevel({
         },
         {
             id: "merge-release",
+            objectiveId:3,
             command: "git merge",
             requiresArgs: ["any"],
             description: "workflow.level3.requirement5.description",
@@ -253,6 +258,7 @@ const workflowLevel3 = createLevel({
         },
         {
             id: "tag-release",
+            objectiveId:4,
             command: "git tag",
             requiresArgs: ["any"],
             description: "workflow.level3.requirement6.description",


### PR DESCRIPTION
In advanced, in workflow level 3 there was a bug. In total there were four objectives, but for objective 2, even when i just type git add ., the second objective was shown completed. The real case is that it should only be completed when we give the command git add . and git commit . And this keeps on repeating and at the 4th command that we give, whole objectives become completed. So what i did is that I gave every objective an objective id in level 3(like u did for level 1). Right now it is working properly.