### PR TITLE
Fix all 85 pre-existing failing tests — green test suite (507/507)

### DIFF
--- a/src/models/GitRepository.ts
+++ b/src/models/GitRepository.ts
@@ -198,7 +198,7 @@ export class GitRepository {
         return stagedFiles;
     }
 
-    public commit(message: string): string | null {
+    public commit(message: string, allowEmpty = false): string | null {
         if (!this.initialized) return null;
 
         const currentBranchState = this.branchStates[this.currentBranch];
@@ -208,7 +208,9 @@ export class GitRepository {
             .filter(([_, status]) => status === "staged")
             .map(([file]) => file);
 
-        if (stagedFiles.length === 0) return null;
+        // Normally a commit needs staged files; allowEmpty supports branch-marker
+        // commits (git commit --allow-empty), used e.g. when setting up level history.
+        if (stagedFiles.length === 0 && !allowEmpty) return null;
 
         const commitId = this.generateCommitId();
         const lastCommitId = currentBranchState.commits[currentBranchState.commits.length - 1];

--- a/src/models/LevelManager.ts
+++ b/src/models/LevelManager.ts
@@ -101,7 +101,12 @@ export class LevelManager {
 
                 // Create branches if specified
                 if (gitState.branches) {
+                    const existingBranches = gitRepository.getBranches();
                     for (const branch of gitState.branches) {
+                        // Skip branches that already exist (e.g. the default "main" created by init())
+                        if (existingBranches.includes(branch)) {
+                            continue;
+                        }
                         if (!gitRepository.createBranch(branch)) {
                             console.warn(`Failed to create branch: ${branch}`);
                             return false;
@@ -128,8 +133,10 @@ export class LevelManager {
                                 gitRepository.addFile(filePath);
                             }
 
-                            // Commit the changes
-                            const commitId = gitRepository.commit(commit.message);
+                            // Commit the changes. Branch-marker commits legitimately have no
+                            // files (e.g. "Create develop branch"), so allow empty commits here.
+                            const allowEmpty = commit.files.length === 0;
+                            const commitId = gitRepository.commit(commit.message, allowEmpty);
                             if (!commitId) {
                                 console.warn(`Failed to create commit: ${commit.message}`);
                                 return false;

--- a/src/test/commands/git-advanced.test.ts
+++ b/src/test/commands/git-advanced.test.ts
@@ -142,6 +142,7 @@ describe('Git Advanced Commands', () => {
 
     it('should restore modified files', () => {
       context.fileSystem.writeFile('/README.md', 'Modified');
+      context.gitRepository.updateFileStatus('README.md', 'modified');
 
       const restoreCmd = new RestoreCommand();
       const output = restoreCmd.execute(
@@ -182,6 +183,7 @@ describe('Git Advanced Commands', () => {
 
     it('should stash changes', () => {
       context.fileSystem.writeFile('/README.md', 'Modified');
+      context.gitRepository.updateFileStatus('README.md', 'modified');
 
       const stashCmd = new StashCommand();
       const output = stashCmd.execute({ args: [], flags: {}, positionalArgs: [] }, context);
@@ -191,6 +193,7 @@ describe('Git Advanced Commands', () => {
 
     it('should list stashes', () => {
       context.fileSystem.writeFile('/README.md', 'Modified');
+      context.gitRepository.updateFileStatus('README.md', 'modified');
       const stashCmd = new StashCommand();
       stashCmd.execute({ args: [], flags: {}, positionalArgs: [] }, context);
 
@@ -204,6 +207,7 @@ describe('Git Advanced Commands', () => {
 
     it('should pop stash', () => {
       context.fileSystem.writeFile('/README.md', 'Modified');
+      context.gitRepository.updateFileStatus('README.md', 'modified');
       const stashCmd = new StashCommand();
       stashCmd.execute({ args: [], flags: {}, positionalArgs: [] }, context);
 
@@ -212,7 +216,9 @@ describe('Git Advanced Commands', () => {
         context
       );
 
-      expect(output[0]).toContain('Dropped refs/stash');
+      // Real `git stash pop` prints the working-tree status first and the
+      // "Dropped refs/stash" line last, so check across all output lines.
+      expect(output.some(line => line.includes('Dropped refs/stash'))).toBe(true);
     });
 
     it('should fail to pop when no stash exists', () => {

--- a/src/test/commands/git-merge.test.ts
+++ b/src/test/commands/git-merge.test.ts
@@ -98,6 +98,8 @@ describe("git merge", () => {
         // Create feature branch with file2 and modified file1
         commandProcessor.processCommand("git switch -c feature");
         fileSystem.writeFile("/file1.txt", "modified");
+        // Editing a tracked file marks it modified (the editor does this in the app)
+        gitRepository.updateFileStatus("file1.txt", "modified");
         fileSystem.writeFile("/file2.txt", "new file");
         commandProcessor.processCommand("git add .");
         commandProcessor.processCommand("git commit -m 'Feature changes'");

--- a/src/test/levels/e2e-all-levels.test.ts
+++ b/src/test/levels/e2e-all-levels.test.ts
@@ -23,6 +23,8 @@ import { splitCommandRespectingQuotes } from "~/commands/base/CommandParser";
 type LevelSolution = {
     commands: string[];
     preActions?: (fs: FileSystem, git: GitRepository, cmd: CommandProcessor) => void;
+    postPullAction?: (fs: FileSystem, git: GitRepository, cmd: CommandProcessor) => void;
+    commandsAfterStateCheck?: string[];
     description?: string;
 };
 

--- a/src/test/levels/intro.test.ts
+++ b/src/test/levels/intro.test.ts
@@ -5,6 +5,7 @@ import { LevelManager } from "~/models/LevelManager";
 import { allStages } from "~/levels";
 import type { CommandContext } from "~/commands/base/Command";
 import { InitCommand } from "~/commands/git/InitCommand";
+import { ProgressManager } from "~/models/ProgressManager";
 
 describe("Intro Stage Levels", () => {
     let fileSystem: FileSystem;
@@ -24,6 +25,7 @@ describe("Intro Stage Levels", () => {
             setCurrentDirectory: (path: string) => {
                 context.currentDirectory = path;
             },
+            progressManager: new ProgressManager(),
         };
     });
 

--- a/src/test/models/gitrepository-multidirectory.test.ts
+++ b/src/test/models/gitrepository-multidirectory.test.ts
@@ -4,6 +4,7 @@ import { GitRepository } from "~/models/GitRepository";
 import { InitCommand } from "~/commands/git/InitCommand";
 import { StatusCommand } from "~/commands/git/StatusCommand";
 import type { CommandContext } from "~/commands/base/Command";
+import { ProgressManager } from "~/models/ProgressManager";
 
 describe("Git Repository Multi-Directory Support", () => {
     let fileSystem: FileSystem;
@@ -26,6 +27,7 @@ describe("Git Repository Multi-Directory Support", () => {
             setCurrentDirectory: (path: string) => {
                 context.currentDirectory = path;
             },
+            progressManager: new ProgressManager(),
         };
     });
 

--- a/src/test/push-command.test.ts
+++ b/src/test/push-command.test.ts
@@ -17,8 +17,12 @@ describe("PushCommand with --set-upstream", () => {
         gitRepository = new GitRepository(fileSystem);
         progressManager = new ProgressManager();
 
-        // Setup: init git, create a branch, make a commit
+        // Setup: init git, add the remote, create a branch, make a commit.
+        // checkout(name, true) only verifies an already-created branch (as `git switch -c`
+        // does), so the branch must be created explicitly first.
         gitRepository.init();
+        gitRepository.addRemote("origin", "https://github.com/user/repo.git");
+        gitRepository.createBranch("feature/test");
         gitRepository.checkout("feature/test", true);
         fileSystem.writeFile("/test.txt", "test content");
         gitRepository.addFile("/test.txt");


### PR DESCRIPTION
## Summary

The repository carried **85 failing tests on `main`** (they predate the recent bugfix/roadmap PRs). This PR root-causes and fixes **all of them** — the suite now runs **507/507 green**, with `tsc` and `next build` clean.

Each failure was classified as either a genuine simulator bug or a stale test, and fixed accordingly.

### 🐞 Genuine simulator bugs (2) — these also affected level setup in the app
1. **Redundant branch in level setup aborted everything.** `LevelManager.setupGitState` called `createBranch` for every branch listed in a level, including the default `main` that `init()` already creates. `createBranch("main")` returns `false`, which aborted the whole setup — so subsequent branches/commits were never created and `setupLevel` returned `false`. Now already-existing branches are skipped. **This one fix cleared ~60 of the e2e failures.**
2. **Branch-marker commits couldn't be created.** Levels use commits with an empty `files` array (e.g. `"Create develop branch"`). `commit()` requires staged files, so these aborted setup for `merge/1`, `stash/1`, etc. Added `git commit --allow-empty` support — `commit(message, allowEmpty)` — and use it for empty-file setup commits.

### 🧪 Stale/incomplete test setups — simulator was correct, tests bypassed status tracking
- **push-command (3):** never added a remote, and used `checkout(name, true)` expecting it to *create* the branch (that overload only verifies an already-created branch, exactly as `git switch -c` relies on). Added `addRemote` + `createBranch`.
- **git-advanced / stash (2):** wrote files directly without marking them modified, so `git stash` correctly reported *"No local changes to save"*; the pop test also asserted on `output[0]` instead of scanning lines. Added `updateFileStatus` and relaxed the assertion to match real `git stash pop` output order (status first, `Dropped refs/stash` last).
- **git-merge (1):** modified a tracked file without marking it modified, so `git add .` never staged it and a fast-forward merge carried the old content. Added `updateFileStatus` — which is exactly what the file editor does in the app.

### 🔧 Typecheck
Fixed the 3 pre-existing `tsc` errors in test files (missing `progressManager` in two hand-built contexts; missing optional fields on the e2e `LevelSolution` type) so `tsc --noEmit` is clean.

## Why the app wasn't visibly broken
The two simulator bugs are **latent**: most level completion is command-based, so users rarely noticed the missing setup branches/commits. The strict e2e `setupLevel === true` assertions exposed them.

## Verification
- **`vitest run`: 507/507 pass** (was 85 failing)
- `tsc --noEmit`: clean
- `next build` (static export): ✓

## Relationship to the CI PR (#82)
#82 adds `.github/workflows/ci.yml` with the `vitest` job marked *informational* precisely because of these 85 failures. **Once this PR and #82 are both merged, the `vitest` job can be promoted to a required gate** (a one-line change to `continue-on-error`). Happy to do that flip as a small follow-up. The two PRs are independent (the small overlaps — the 3 tsc test fixes and different parts of `LevelManager.ts` — are identical or non-conflicting edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138HAknwEp8XFTDoBWztigs

---
_Generated by [Claude Code](https://claude.ai/code/session_0138HAknwEp8XFTDoBWztigs)_