### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,11 @@ Your support helps this educational tool reach more developers!
 ## 📈 Star History
 
 <div align="center">
-  <a href="https://star-history.com/#MikaStiebitz/Git-Mastery&Date">
+  <a href="https://star-history.dera.page/#MikaStiebitz/Git-Mastery&Date">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=MikaStiebitz/Git-Mastery&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=MikaStiebitz/Git-Mastery&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=MikaStiebitz/Git-Mastery&type=Date" width="600" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=MikaStiebitz/Git-Mastery&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=MikaStiebitz/Git-Mastery&type=Date" />
+      <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=MikaStiebitz/Git-Mastery&type=Date" width="600" />
     </picture>
   </a>
 </div>


### PR DESCRIPTION
The star history chart in the README is currently broken and not rendering for visitors, which undercuts a nice showcase of the project's growth.

This MR points the chart (and its wrapping link) at a working alternative so the graph displays correctly again. It only touches the README star history section and leaves the rest of the file unchanged.